### PR TITLE
Strip any leading null characters from data before trying to parse message

### DIFF
--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -294,6 +294,8 @@ class AlarmDecoder(object):
 
         :returns: :py:class:`~alarmdecoder.messages.Message`
         """
+        data = data.lstrip('\0')
+
         if data is None:
             raise InvalidMessageError()
 


### PR DESCRIPTION
If the decoder encounters any leading null characters, decoder will think it is a keypad message, the message parser will not match, it will raise InvalidMessageError and the input reading thread will stop. This patch removes any leading '\0' characters, and the decoder will not get confused.
