### PR TITLE
format the code block properly by using a :: end paragraph marker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Examples
 --------
 
 A basic example is included below. Please see the `examples`_ directory for
-more.:
+more.::
 
     import time
     from alarmdecoder import AlarmDecoder


### PR DESCRIPTION
The README.rst formats the code block oddly on github.  Adding a second colon fixes this.  It also stops the following error from being printed:
$rst2html.py < README.rst > README.html
<stdin>:75: (ERROR/3) Unexpected indentation.
<stdin>:81: (ERROR/3) Unexpected indentation.
