### PR TITLE
Fix issue #15 - allow multiple calls to open if it fails

### DIFF
--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -795,7 +795,7 @@ class AlarmDecoder(object):
             if fire_status == True:
                 self._fire_state = FireState.ALARM
                 self._fire_status = (fire_status, time.time())
-                
+
                 self.on_fire(status=FireState.ALARM)
 
         elif self._fire_state == FireState.ALARM:

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -262,7 +262,6 @@ class AlarmDecoder(object):
         :param no_reader_thread: Specifies whether or not the automatic reader
                                  thread should be started.
         :type no_reader_thread: bool
-
         """
         self._wire_events()
         try:

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -152,7 +152,6 @@ class AlarmDecoder(object):
         self._panic_status = False
         self._relay_status = {}
         self._internal_address_mask = 0xFFFFFFFF
-
         self.last_fault_expansion = 0
         self.fault_expansion_time_limit = 30  # Seconds
 
@@ -253,7 +252,7 @@ class AlarmDecoder(object):
     def open(self, baudrate=None, no_reader_thread=False):
         """Opens the device.
 
-        If the device cannot be opened, an except is thrown.  In that
+        If the device cannot be opened, an exception is thrown.  In that
         case, open() can be called repeatedly to try and open the
         connection.
 
@@ -796,7 +795,6 @@ class AlarmDecoder(object):
             if fire_status == True:
                 self._fire_state = FireState.ALARM
                 self._fire_status = (fire_status, time.time())
-
                 self.on_fire(status=FireState.ALARM)
 
         elif self._fire_state == FireState.ALARM:

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -152,6 +152,7 @@ class AlarmDecoder(object):
         self._panic_status = False
         self._relay_status = {}
         self._internal_address_mask = 0xFFFFFFFF
+        
         self.last_fault_expansion = 0
         self.fault_expansion_time_limit = 30  # Seconds
 
@@ -795,6 +796,7 @@ class AlarmDecoder(object):
             if fire_status == True:
                 self._fire_state = FireState.ALARM
                 self._fire_status = (fire_status, time.time())
+                
                 self.on_fire(status=FireState.ALARM)
 
         elif self._fire_state == FireState.ALARM:
@@ -807,7 +809,7 @@ class AlarmDecoder(object):
                 # Handle bouncing status changes and timeout in order to revert back to NONE.
                 if last_status != fire_status or fire_status == True:
                     self._fire_status = (fire_status, time.time())
-
+                
                 if fire_status == False and time.time() > last_update + self._fire_timeout:
                     self._fire_state = FireState.NONE
                     self.on_fire(status=FireState.NONE)

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -1,11 +1,6 @@
 from unittest import TestCase
 from mock import Mock, MagicMock, patch
 from serial import Serial, SerialException
-try:
-    from pyftdi.pyftdi.ftdi import Ftdi, FtdiError
-except:
-    from pyftdi.ftdi import Ftdi, FtdiError
-from usb.core import USBError, Device as USBCoreDevice
 import sys
 import socket
 import time

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -1,6 +1,11 @@
 from unittest import TestCase
 from mock import Mock, MagicMock, patch
 from serial import Serial, SerialException
+try:
+    from pyftdi.pyftdi.ftdi import Ftdi, FtdiError
+except:
+    from pyftdi.ftdi import Ftdi, FtdiError
+from usb.core import USBError, Device as USBCoreDevice
 import sys
 import socket
 import time


### PR DESCRIPTION
I added an unwire events method and put a try catch around the open to insure that if open fails, the connects are reset.  I wasn't able to get a unit test working (had trouble understanding how to get the mock system to do a failure) but I've tested it with a stand alone script that connects to ser2sock and prints the connections and messages.  I can connect w/o ser2sock running and once ser2sock is started, it will connect and work properly.  It also handles the connection going down and repeated reconnections via open without any problems so I think it's working fine.

I also removed the deletion of the device member variable in close.  That variable can never be None so the check is not needed and if the variable is removed when close is called (like when the connection is dropped), then a reconnect by calling open() is no longer possible.

This fix should close issue #15 