### PR TITLE
added on_ready_change event handler and tests

### DIFF
--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -776,8 +776,10 @@ class AlarmDecoder(object):
         if isinstance(message, Message):
             arm_status = message.armed_away
             stay_status = message.armed_home
+
         if arm_status is None or stay_status is None:
             return
+
         self._armed_status, old_status = arm_status, self._armed_status
         self._armed_stay, old_stay = stay_status, self._armed_stay
         if arm_status != old_status or stay_status != old_stay:

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -123,7 +123,7 @@ class AlarmDecoder(object):
     version_flags = ""
     """Device flags enabled"""
 
-    def __init__(self, device, ignore_message_states=False):
+    def __init__(self, device, ignore_message_states=False, ignore_lrr_states=True):
         """
         Constructor
 
@@ -132,12 +132,15 @@ class AlarmDecoder(object):
         :type device: Device
         :param ignore_message_states: Ignore regular panel messages when updating internal states
         :type ignore_message_states: bool
+        :param ignore_lrr_states: Ignore LRR panel messages when updating internal states
+        :type ignore_lrr_states: bool
         """
         self._device = device
         self._zonetracker = Zonetracker(self)
         self._lrr_system = LRRSystem(self)
 
         self._ignore_message_states = ignore_message_states
+        self._ignore_lrr_states = ignore_lrr_states
         self._battery_timeout = AlarmDecoder.BATTERY_TIMEOUT
         self._fire_timeout = AlarmDecoder.FIRE_TIMEOUT
         self._power_status = None
@@ -146,10 +149,7 @@ class AlarmDecoder(object):
         self._bypass_status = {}
         self._armed_status = None
         self._armed_stay = False
-        self._fire_status = (False, 0)
-        self._fire_alarming = False
-        self._fire_alarming_changed = 0
-        self._fire_state = FireState.NONE
+        self._fire_status = False
         self._battery_status = (False, 0)
         self._panic_status = False
         self._relay_status = {}
@@ -470,8 +470,6 @@ class AlarmDecoder(object):
         if self._internal_address_mask & msg.mask > 0:
             if not self._ignore_message_states:
                 self._update_internal_states(msg)
-            else:
-                self._update_fire_status(status=None)
 
             self.on_message(message=msg)
 
@@ -519,7 +517,8 @@ class AlarmDecoder(object):
         """
         msg = LRRMessage(data)
 
-        self._lrr_system.update(msg)
+        if not self._ignore_lrr_states:
+            self._lrr_system.update(msg)
         self.on_lrr_message(message=msg)
 
         return msg
@@ -812,54 +811,26 @@ class AlarmDecoder(object):
 
         :returns: boolean indicating the new status
         """
-        is_lrr = status is not None
         fire_status = status
+        last_status = self._fire_status
         if isinstance(message, Message):
-            fire_status = message.fire_alarm
-
-        last_status, last_update = self._fire_status
-
-        if self._fire_state == FireState.NONE:
-            # Always move to a FIRE state if detected
-            if fire_status == True:
-                self._fire_state = FireState.ALARM
-                self._fire_status = (fire_status, time.time())
-
-                self.on_fire(status=FireState.ALARM)
-
-        elif self._fire_state == FireState.ALARM:
-            # If we've received an LRR CANCEL message, move to ACKNOWLEDGED
-            if is_lrr and fire_status == False:
-                self._fire_state = FireState.ACKNOWLEDGED
-                self._fire_status = (fire_status, time.time())
-                self.on_fire(status=FireState.ACKNOWLEDGED)
+            # Quirk in Ademco panels. The fire bit drops on "SYSTEM LO BAT" messages.
+            # needs to be done for different languages.
+            if self.mode == ADEMCO and message.text.startswith("SYSTEM"):
+                fire_status = last_status
             else:
-                # Handle bouncing status changes and timeout in order to revert back to NONE.
-                if last_status != fire_status or fire_status == True:
-                    self._fire_status = (fire_status, time.time())
-                
-                if fire_status == False and time.time() > last_update + self._fire_timeout:
-                    self._fire_state = FireState.NONE
-                    self.on_fire(status=FireState.NONE)
+                fire_status = message.fire_alarm
 
-        elif self._fire_state == FireState.ACKNOWLEDGED:
-            # If we've received a second LRR FIRE message after a CANCEL, revert back to FIRE and trigger another event.
-            if is_lrr and fire_status == True:
-                self._fire_state = FireState.ALARM
-                self._fire_status = (fire_status, time.time())
+        if fire_status is None:
+            return
 
-                self.on_fire(status=FireState.ALARM)
-            else:
-                # Handle bouncing status changes and timeout in order to revert back to NONE.
-                if last_status != fire_status or fire_status == True:
-                    self._fire_status = (fire_status, time.time())
+        if fire_status != self._fire_status:
+            self._fire_status, old_status = fire_status, self._fire_status
 
-                if fire_status != True and time.time() > last_update + self._fire_timeout:
-                    self._fire_state = FireState.NONE
-                    self.on_fire(status=FireState.NONE)
+            if old_status is not None:
+                self.on_fire(status=self._fire_status)
 
-        return self._fire_state == FireState.ALARM
-
+        return self._fire_status
 
     def _update_panic_status(self, status=None):
         """

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -415,7 +415,10 @@ class AlarmDecoder(object):
         :returns: :py:class:`~alarmdecoder.messages.Message`
         """
 
-        data = data.decode('utf-8')
+        try:
+            data = data.decode('utf-8')
+        except:
+            raise InvalidMessageError('Decode failed for message: {0}'.format(data))
 
         if data is not None:
             data = data.lstrip('\0')

--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -647,32 +647,6 @@ class AlarmDecoder(object):
 
         return self._power_status
 
-    def _update_ready_status(self, message=None, status=None):
-        """
-        Uses the provided message to update the ready state.
-
-        :param message: message to use to update
-        :type message: :py:class:`~alarmdecoder.messages.Message`
-        :param status: ready status, overrides message bits.
-        :type status: bool
-
-        :returns: bool indicating the new status
-        """
-        ready_status = status
-        if isinstance(message, Message):
-            ready_status = message.ready
-
-        if ready_status is None:
-            return
-
-        if ready_status != self._ready_status:
-            self._ready_status, old_status = ready_status, self._ready_status
-
-            if old_status is not None:
-                self.on_ready_changed(status=self._ready_status)
-
-        return self._ready_status
-
     def _update_alarm_status(self, message=None, status=None, zone=None, user=None):
         """
         Uses the provided message to update the alarm state.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info < (3,):
     extra_requirements.append('future==0.14.3')
 
 setup(name='alarmdecoder',
-    version='1.13.2',
+    version='1.13.3',
     description='Python interface for the AlarmDecoder (AD2) family '
                 'of alarm devices which includes the AD2USB, AD2SERIAL and AD2PI.',
     long_description=readme(),

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -43,7 +43,7 @@ class TestAlarmDecoder(TestCase):
         self._device.on_read = EventHandler(Event(), self._device)
         self._device.on_write = EventHandler(Event(), self._device)
 
-        self._decoder = AlarmDecoder(self._device)
+        self._decoder = AlarmDecoder(self._device, ignore_lrr_states=False)
         self._decoder.on_panic += self.on_panic
         self._decoder.on_relay_changed += self.on_relay_changed
         self._decoder.on_power_changed += self.on_power_changed
@@ -305,7 +305,7 @@ class TestAlarmDecoder(TestCase):
 
     def test_fire_alarm_event(self):
         msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
-        self.assertTrue(self._fire)   # Not set the first time we hit it.
+        self.assertFalse(self._fire)   # Not set the first time we hit it.
 
         msg = self._decoder._handle_message(b'[0000000000000100----],000,[f707000600e5800c0c020000],"                                "')
         self.assertTrue(self._fire)

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -253,7 +253,7 @@ class TestAlarmDecoder(TestCase):
         self.assertTrue(self._ready_changed)
 
         msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
-        self.assertTrue(self._ready_changed)
+        self.assertFalse(self._ready_changed)
 
 
     def test_alarm_event(self):

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -304,32 +304,23 @@ class TestAlarmDecoder(TestCase):
             self.assertFalse(self._battery)
 
     def test_fire_alarm_event(self):
-        self._fire = FireState.NONE
+        msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
+        self.assertTrue(self._fire)   # Not set the first time we hit it.
 
         msg = self._decoder._handle_message(b'[0000000000000100----],000,[f707000600e5800c0c020000],"                                "')
-        self.assertEquals(self._fire, FireState.ALARM)
-
-        # force the timeout to expire.
-        with patch.object(time, 'time', return_value=self._decoder._fire_status[1] + 35):
-            msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
-            self.assertEquals(self._fire, FireState.NONE)
+        self.assertTrue(self._fire)
 
     def test_fire_lrr(self):
-        self._fire = FireState.NONE
+        self._fire = False
 
         msg = self._decoder._handle_message(b'!LRR:095,1,CID_1110,ff') # Fire: Non-specific
 
         self.assertIsInstance(msg, LRRMessage)
-        self.assertEquals(self._fire, FireState.ALARM)
+        self.assertTrue(self._fire)
 
         msg = self._decoder._handle_message(b'!LRR:001,1,CID_1406,ff') # Open/Close: Cancel
         self.assertIsInstance(msg, LRRMessage)
-        self.assertEquals(self._fire, FireState.ACKNOWLEDGED)
-
-        # force the timeout to expire.
-        with patch.object(time, 'time', return_value=self._decoder._fire_status[1] + 35):
-            msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
-            self.assertEquals(self._fire, FireState.NONE)
+        self.assertFalse(self._fire)
 
     def test_hit_for_faults(self):
         self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"Hit * for faults                "')

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -20,6 +20,7 @@ class TestAlarmDecoder(TestCase):
         self._panicked = False
         self._relay_changed = False
         self._power_changed = False
+        self._ready_changed = False
         self._alarmed = False
         self._bypassed = False
         self._battery = False
@@ -46,6 +47,7 @@ class TestAlarmDecoder(TestCase):
         self._decoder.on_panic += self.on_panic
         self._decoder.on_relay_changed += self.on_relay_changed
         self._decoder.on_power_changed += self.on_power_changed
+        self._decoder.on_ready_changed += self.on_ready_changed
         self._decoder.on_alarm += self.on_alarm
         self._decoder.on_alarm_restored += self.on_alarm_restored
         self._decoder.on_bypass += self.on_bypass
@@ -78,6 +80,9 @@ class TestAlarmDecoder(TestCase):
 
     def on_power_changed(self, sender, *args, **kwargs):
         self._power_changed = kwargs['status']
+
+    def on_ready_changed(self, sender, *args, **kwargs):
+        self._ready_changed = kwargs['status']
 
     def on_alarm(self, sender, *args, **kwargs):
         self._alarmed = True
@@ -239,6 +244,17 @@ class TestAlarmDecoder(TestCase):
 
         msg = self._decoder._handle_message(b'[0000000100000000----],000,[f707000600e5800c0c020000],"                                "')
         self.assertTrue(self._power_changed)
+
+    def test_ready_changed_event(self):
+        msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
+        self.assertFalse(self._ready_changed)   # Not set first time we hit it.
+
+        msg = self._decoder._handle_message(b'[1000000000000000----],000,[f707000600e5800c0c020000],"                                "')
+        self.assertFalse(self._ready_changed)
+
+        msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
+        self.assertTrue(self._ready_changed)
+
 
     def test_alarm_event(self):
         msg = self._decoder._handle_message(b'[0000000000100000----],000,[f707000600e5800c0c020000],"                                "')

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -250,7 +250,7 @@ class TestAlarmDecoder(TestCase):
         self.assertFalse(self._ready_changed)   # Not set first time we hit it.
 
         msg = self._decoder._handle_message(b'[1000000000000000----],000,[f707000600e5800c0c020000],"                                "')
-        self.assertFalse(self._ready_changed)
+        self.assertTrue(self._ready_changed)
 
         msg = self._decoder._handle_message(b'[0000000000000000----],000,[f707000600e5800c0c020000],"                                "')
         self.assertTrue(self._ready_changed)


### PR DESCRIPTION
- This addition allows notification on the panel ready state change. Useful to know if you can arm the alarm or not or arming will just fail and the remote end will not know why. 
- Fixed some of the issue with events getting different panel states upon the same message from the panel.
- Turned off processing of LRR messages into events by default as it was causing fire to bounce.
- Disable timeouts on fire. Fire is fire till it is turned off. Maybe the LRR processing could be ok with this change but will leave off for now. Eventually it would also be nice to add AUI event processing so we get the fastest update possible since standard messages are slower.