### PR TITLE
Serial read_line fixes

### DIFF
--- a/alarmdecoder/devices/serial_device.py
+++ b/alarmdecoder/devices/serial_device.py
@@ -189,7 +189,7 @@ class SerialDevice(Device):
         except serial.SerialException as err:
             raise CommError('Error reading from device: {0}'.format(str(err)), err)
 
-        return data
+        return data.decode('utf-8')
 
     def read_line(self, timeout=0.0, purge_buffer=False):
         """
@@ -252,7 +252,7 @@ class SerialDevice(Device):
         finally:
             timer.cancel()
 
-        return ret
+        return ret.decode('utf-8')
 
     def purge(self):
         """

--- a/alarmdecoder/devices/serial_device.py
+++ b/alarmdecoder/devices/serial_device.py
@@ -229,7 +229,7 @@ class SerialDevice(Device):
                 buf = filter_ad2prot_byte(self._device.read(1))
 
                 if buf != b'':
-                    self._buffer +=  buf[0]
+                    self._buffer += buf
 
                     if buf == b"\n":
                         self._buffer = self._buffer.rstrip(b"\r\n")

--- a/alarmdecoder/util.py
+++ b/alarmdecoder/util.py
@@ -97,14 +97,14 @@ def filter_ad2prot_byte(buf):
     """
     Return the byte sent in back if valid visible terminal characters or line terminators.
     """
-    c = buf[0];
+    c = buf[0]
 
-    if (c == '\n' or c == '\r'):
-        return c
+    if (c == 10 or c == 13):
+        return buf
     if (c > 31 and c < 127):
-        return c
+        return buf
     else:
-        return ''
+        return b''
 
 def read_firmware_file(file_path):
     """


### PR DESCRIPTION
This PR updates the `read_line` method (and an associated function, `filter_ad2prot_byte`) in the `SerialDevice` class.

In `serial_device.py`, `self._buffer +=  buf[0]` was changed to `self._buffer += buf` so that the byte objects can be correctly concatenated (`buf[0]` returns an `int`, so it was trying to incorrectly concatenate a byte object with an `int` prior to this change).

In `util.py`, `filter_ad2prot_byte` was updated to correctly return a byte object (as indicated in `filter_ad2prot_byte`'s docstring) instead of an `int`/`str` and also to compare against the ASCII values for `\n` and `\r` instead of the string representations.

These changes were tested locally and seemed to resolve the issues described in #40 and #47.