### PR TITLE
Fix Broken Unit Tests

### DIFF
--- a/alarmdecoder/util.py
+++ b/alarmdecoder/util.py
@@ -97,7 +97,10 @@ def filter_ad2prot_byte(buf):
     """
     Return the byte sent in back if valid visible terminal characters or line terminators.
     """
-    c = buf[0]
+    if sys.version_info > (3,):
+        c = buf[0]
+    else:
+        c = ord(buf)
 
     if (c == 10 or c == 13):
         return buf

--- a/test/test_ad2.py
+++ b/test/test_ad2.py
@@ -363,4 +363,6 @@ class TestAlarmDecoder(TestCase):
         self.assertEquals(self._zone_faulted, 5)
 
         self._decoder._on_read(self, data=b'[00010001000000000A--],004,[f70000051003000008020000000000],"FAULT 04                        "')
+        self._decoder._on_read(self, data=b'[00010001000000000A--],004,[f70000051003000008020000000000],"FAULT 05                        "')
+        self._decoder._on_read(self, data=b'[00010001000000000A--],004,[f70000051003000008020000000000],"FAULT 04                        "')
         self.assertEquals(self._zone_restored, 3)

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -81,7 +81,7 @@ class TestSerialDevice(TestCase):
         self._device.interface = '/dev/ttyS0'
         self._device.open(no_reader_thread=True)
 
-        with patch.object(self._device._device, 'read') as mock:
+        with patch.object(self._device._device, 'read', return_value=[1]) as mock:
             with patch('serial.Serial.fileno', return_value=1):
                 with patch.object(select, 'select', return_value=[[1], [], []]):
                     ret = self._device.read()

--- a/test/test_devices.py
+++ b/test/test_devices.py
@@ -80,8 +80,11 @@ class TestSerialDevice(TestCase):
     def test_read(self):
         self._device.interface = '/dev/ttyS0'
         self._device.open(no_reader_thread=True)
+        side_effect = ["t"]
+        if sys.version_info > (3,):
+            side_effect = ["t".encode('utf-8')]
 
-        with patch.object(self._device._device, 'read', return_value=[1]) as mock:
+        with patch.object(self._device._device, 'read', side_effect=side_effect) as mock:
             with patch('serial.Serial.fileno', return_value=1):
                 with patch.object(select, 'select', return_value=[[1], [], []]):
                     ret = self._device.read()


### PR DESCRIPTION
This PR updates the Python 3 unit tests for the changes that were introduced in both https://github.com/nutechsoftware/alarmdecoder/commit/d809cb34cd6123088aa29e94f7b40897f7e7b40a and #52.

There may be some Python 2 unit tests still failing, but that's been EOL for over a year now so I'm not sure it's worth fixing them.

Hoping this helps us move closer to a new AlarmDecoder release being published.

(cc @endlesscoil, @f34rdotcom).