### PR TITLE
Parse regex result as `int`

### DIFF
--- a/alarmdecoder/zonetracking.py
+++ b/alarmdecoder/zonetracking.py
@@ -189,7 +189,7 @@ class Zonetracker(object):
                     if match is None:
                         return
 
-                    zone = match.group(1)
+                    zone = int(match.group(1))
 
                 # Add new zones and clear expired ones.
                 if zone in self._zones_faulted:

--- a/test/test_zonetracking.py
+++ b/test/test_zonetracking.py
@@ -76,7 +76,7 @@ class TestZonetracking(TestCase):
         msg = Message('[00000000000000100A--],0bf,[f707000600e5800c0c020000],"CHECK 1                         "')
         self._zonetracker.update(msg)
 
-        self.assertEqual(self._zonetracker._zones['1'].status, Zone.CHECK)
+        self.assertEqual(self._zonetracker._zones[1].status, Zone.CHECK)
 
     def test_zone_restore_skip(self):
         panel_messages = [


### PR DESCRIPTION
This PR should fix #59, where zone values are being returned as strings rather than numbers.

Closes #59.