### PR TITLE
Be Sure that Expander Zones are Marked as Such

### DIFF
--- a/alarmdecoder/zonetracking.py
+++ b/alarmdecoder/zonetracking.py
@@ -154,6 +154,7 @@ class Zonetracker(object):
                 #       regular messages.
                 try:
                     self._update_zone(zone, status=status)
+                    self.zones[zone].expander = True
 
                 except IndexError:
                     self._add_zone(zone, status=status, expander=True)


### PR DESCRIPTION
A zone can be initially created by an alphanumeric fault message.
When created this way, the expander attribute is not marked even
for expander zones.

However, when we receive an expander message, we should update
the zone attribute to be sure it is identified as an expander.