### PR TITLE
Handle ValueError during socket device shutdown

### DIFF
--- a/alarmdecoder/devices/socket_device.py
+++ b/alarmdecoder/devices/socket_device.py
@@ -339,7 +339,7 @@ class SocketDevice(Device):
                             got_line = True
                             break
 
-        except socket.error as err:
+        except (socket.error, ValueError) as err:
             raise CommError('Error reading from device: {0}'.format(str(err)), err)
 
         except SSL.SysCallError as err:


### PR DESCRIPTION
When the socket is closed down unexpectedly a `ValueError` can be thrown while waiting for a message:
```python
2022-02-05 13:49:03 ERROR (Thread-3) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/srv/homeassistant/venv/lib/python3.9/site-packages/alarmdecoder/devices/base_device.py", line 148, in run
    self._device.read_line(timeout=self.READ_TIMEOUT)
  File "/srv/homeassistant/venv/lib/python3.9/site-packages/alarmdecoder/devices/socket_device.py", line 323, in read_line
    read_ready, _, _ = select.select([self._device], [], [], 0.5)
ValueError: file descriptor cannot be a negative integer (-1)
```

Fixes #64