### PR TITLE
Fix firmware compatibility and regex issues

### DIFF
--- a/alarmdecoder/decoder.py
+++ b/alarmdecoder/decoder.py
@@ -602,7 +602,7 @@ class AlarmDecoder(object):
         :type data: string
         """
 
-        matches = re.match('^!Sending(\.{1,5})done.*', data)
+        matches = re.match(r'^!Sending(\.{1,5})done.*', data)
         if matches is not None:
             good_send = False
             if len(matches.group(1)) < 5:

--- a/alarmdecoder/messages/panel_message.py
+++ b/alarmdecoder/messages/panel_message.py
@@ -70,7 +70,7 @@ class Message(BaseMessage):
     """The panel data field associated with this message."""
 
 
-    _regex = re.compile('^(!KPM:){0,1}(\[[a-fA-F0-9\-]+\]),([a-fA-F0-9]+),(\[[a-fA-F0-9]+\]),(".+")$')
+    _regex = re.compile(r'^(!KPM:){0,1}(\[[a-fA-F0-9\-]+\]),([a-fA-F0-9]+),(\[[a-fA-F0-9]+\]),(".+")$')
 
     def __init__(self, data=None):
         """

--- a/alarmdecoder/messages/panel_message.py
+++ b/alarmdecoder/messages/panel_message.py
@@ -118,7 +118,8 @@ class Message(BaseMessage):
         self.fire_alarm = is_bit_set(14)
         self.check_zone = is_bit_set(15)
         self.perimeter_only = is_bit_set(16)
-        self.system_fault = int(self.bitfield[17], 16)
+        if self.bitfield[17] != '-':
+            self.system_fault = int(self.bitfield[17], 16)
         if self.bitfield[18] in list(PANEL_TYPES):
             self.panel_type = PANEL_TYPES[self.bitfield[18]]
         # pos 20-21 - Unused.

--- a/alarmdecoder/zonetracking.py
+++ b/alarmdecoder/zonetracking.py
@@ -183,7 +183,7 @@ class Zonetracker(object):
                 #       3-digit mode is enabled... so we have to pull it out
                 #       of the alpha message.
                 if zone == 191:
-                    zone_regex = re.compile('^CHECK (\d+).*$')
+                    zone_regex = re.compile(r'^CHECK (\d+).*$')
 
                     match = zone_regex.match(message.text)
                     if match is None:


### PR DESCRIPTION
Older firmware doesn't populate bitfield[17] to indicate system fault, int will raise an exception.
Fix regular expression strings, they are RAW strings in Python 3.