### PR TITLE
Add GitHub Actions workflow for pull requests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+name: pr
+
+on: pull_request
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        # TODO: move test dependencies to a separate file
+        run: |
+          python -m pip install -e .
+          python -m pip install pytest mock
+      - name: Run pytest
+        run: pytest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
       - name: Install dependencies
         # TODO: move test dependencies to a separate file
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 bin/ad2-test
 *~
 .vscode
+venv
+.venv


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run `pytest` on pull requests.

This will help ensure no breaking changes are introduced into the library.

GitHub Actions is free for public repositories on GitHub.