### PR TITLE
Fix faulted zones clearing iteration logic

### DIFF
--- a/alarmdecoder/zonetracking.py
+++ b/alarmdecoder/zonetracking.py
@@ -169,7 +169,7 @@ class Zonetracker(object):
             # NOTE: SYSTEM messages provide inconsistent ready statuses.  This
             #       may need to be extended later for other panels.
             if message.ready and not message.text.startswith("SYSTEM"):
-                for zone in self._zones_faulted:
+                for zone in self._zones_faulted[:]:
                     self._update_zone(zone, Zone.CLEAR)
 
                 self._last_zone_fault = 0


### PR DESCRIPTION
As provided by warthog618 in https://github.com/nutechsoftware/alarmdecoder/issues/54

The restoration based on message.ready is buggy as it iterates over a list it is deleting from.  which results in only half the faulted zones being cleared.  The fix is to iterate over a copy of the list.

I have been running this fix without issue for several months.