### PR TITLE
Remove travis references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: python
-python:
-  - 2.7
-  - 3.6
-install:
-  - pip install -r requirements.txt
-  - pip install nose
-script:
-  - nosetests

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@
 AlarmDecoder
 ============
 
-.. image:: https://travis-ci.org/nutechsoftware/alarmdecoder.svg?branch=master
-    :target: https://travis-ci.org/nutechsoftware/alarmdecoder
+.. image:: https://github.com/nutechsoftware/alarmdecoder/actions/workflows/merge.yaml/badge.svg
+    :target: https://github.com/nutechsoftware/alarmdecoder/actions/workflows/merge.yaml
 
 -------
 Summary


### PR DESCRIPTION
Travis has not been used by AlarmDecoder in many years and I merged a lot of GitHub Actions workflows in #79. Therefore, this PR removes any remaining TravisCI remnants from the repository.