### PR TITLE
Use `setuptools_scm`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,8 @@ if sys.version_info < (3,):
     extra_requirements.append('future>=0.14.3')
 
 setup(name='alarmdecoder',
-    setuptools_git_versioning={
-        "enabled": True,
-    },
-    setup_requires=["setuptools-git-versioning>=2.0,<3"],
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     description='Python interface for the AlarmDecoder (AD2) family '
                 'of alarm devices which includes the AD2USB, AD2SERIAL and AD2PI.',
     long_description=readme(),


### PR DESCRIPTION
This PR replaces `setuptools-git-versioning` with `setuptools_scm`.

`setuptools_scm` is from PyPA, and is therefore more trusted: https://github.com/pypa/setuptools-scm.