### PR TITLE
Fix Python 2 wheel installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,7 @@ setup(name='alarmdecoder',
     tests_require=['nose', 'mock'],
     scripts=['bin/ad2-sslterm', 'bin/ad2-firmwareupload'],
     include_package_data=True,
-    zip_safe=False)
+    zip_safe=False,
+    options={
+        'bdist_wheel': {'universal': 1}
+    })


### PR DESCRIPTION
This PR updates `setup.py` to ensure that the built wheels can be installed by both Python 2 and Python 3 versions.

Fixes #83.